### PR TITLE
Change metafiles for normal map textures

### DIFF
--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_pathwayBlockerDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_pathwayBlockerDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_pathwayDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_pathwayDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_roadDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_roadDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_stairwayCapDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_stairwayCapDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_stairwayDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_stairwayDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_wallCorniceDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_wallCorniceDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_wallDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_wallDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_01.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_01.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_02.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_02.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_03.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_03.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_04.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_04.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_05.png.meta
+++ b/Assets/Models/EnvironmentTextures.fbm/EnvironmentTest.fbm/T_windowDN_N_05.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1


### PR DESCRIPTION
Normal map textures for the background were not changed to be marked as normal maps by Unity.